### PR TITLE
AB#21298 [Vanna-QG] Mask SQL and summarize it instead

### DIFF
--- a/src/vanna/flask/__init__.py
+++ b/src/vanna/flask/__init__.py
@@ -369,9 +369,9 @@ class VannaFlaskAPI:
                 question=question, allow_llm_to_see_data=self.allow_llm_to_see_data
             )
             # Generates a summary of the SQL query
-            summary = vn.generate_sql_summary(question=question, sql=sql)
+            sql_summary = vn.generate_sql_summary(question=question, sql=sql)
             # Style the final output to be more readable
-            results = f"{summary}\n\nSQL Query:\n\n{sql}"
+            summary = f"{sql_summary}\n\nSQL Query:\n\n{sql}"
 
             self.cache.set(user=user, id=id, field="question", value=question)
             self.cache.set(user=user, id=id, field="sql", value=sql)
@@ -381,7 +381,7 @@ class VannaFlaskAPI:
                     {
                         "type": "sql",
                         "id": id,
-                        "text": results,
+                        "text": summary,
                     }
                 )
             else:

--- a/src/vanna/flask/__init__.py
+++ b/src/vanna/flask/__init__.py
@@ -90,7 +90,14 @@ class MemoryCache(Cache):
     def get_all(self, user, field_list) -> list:
         if user in self.cache:
             return [
-                {"user": user, "id": id, **{field: self.get(user=user, id=id, field=field) for field in field_list}}
+                {
+                    "user": user,
+                    "id": id,
+                    **{
+                        field: self.get(user=user, id=id, field=field)
+                        for field in field_list
+                    },
+                }
                 for id in self.cache[user]
             ]
 
@@ -116,7 +123,7 @@ class VannaFlaskAPI:
             @wraps(f)
             def decorated(*args, **kwargs):
 
-                user = kwargs.get('user', None)
+                user = kwargs.get("user", None)
 
                 if user is None:
                     return jsonify({"type": "error", "error": "No user provided"})
@@ -133,7 +140,8 @@ class VannaFlaskAPI:
                         return jsonify({"type": "error", "error": f"No {field} found"})
 
                 field_values = {
-                    field: self.cache.get(user=user, id=id, field=field) for field in required_fields
+                    field: self.cache.get(user=user, id=id, field=field)
+                    for field in required_fields
                 }
 
                 for field in optional_fields:
@@ -154,7 +162,9 @@ class VannaFlaskAPI:
             user = self.auth.get_user(flask.request)
 
             if not self.auth.is_logged_in(user):
-                return jsonify({"type": "not_logged_in", "html": self.auth.login_form()})
+                return jsonify(
+                    {"type": "not_logged_in", "html": self.auth.login_form()}
+                )
 
             # Pass the user to the function
             return f(*args, user=user, **kwargs)
@@ -188,7 +198,7 @@ class VannaFlaskAPI:
         self.flask_app = Flask(__name__)
 
         self.swagger = Swagger(
-          self.flask_app, template={"info": {"title": "Vanna API"}}
+            self.flask_app, template={"info": {"title": "Vanna API"}}
         )
         self.sock = Sock(self.flask_app)
         self.ws_clients = []
@@ -199,20 +209,26 @@ class VannaFlaskAPI:
         self.allow_llm_to_see_data = allow_llm_to_see_data
         self.chart = chart
         self.config = {
-          "debug": debug,
-          "allow_llm_to_see_data": allow_llm_to_see_data,
-          "chart": chart,
+            "debug": debug,
+            "allow_llm_to_see_data": allow_llm_to_see_data,
+            "chart": chart,
         }
         log = logging.getLogger("werkzeug")
         log.setLevel(logging.ERROR)
 
         if "google.colab" in sys.modules:
             self.debug = False
-            print("Google Colab doesn't support running websocket servers. Disabling debug mode.")
+            print(
+                "Google Colab doesn't support running websocket servers. Disabling debug mode."
+            )
 
         if self.debug:
+
             def log(message, title="Info"):
-                [ws.send(json.dumps({'message': message, 'title': title})) for ws in self.ws_clients]
+                [
+                    ws.send(json.dumps({"message": message, "title": title}))
+                    for ws in self.ws_clients
+                ]
 
             self.vn.log = log
 
@@ -237,12 +253,7 @@ class VannaFlaskAPI:
                       type: object
             """
             config = self.auth.override_config_for_user(user, self.config)
-            return jsonify(
-                {
-                    "type": "config",
-                    "config": config
-                }
-            )
+            return jsonify({"type": "config", "config": config})
 
         @self.flask_app.route("/api/v0/generate_questions", methods=["GET"])
         @self.requires_auth
@@ -354,7 +365,13 @@ class VannaFlaskAPI:
                 return jsonify({"type": "error", "error": "No question provided"})
 
             id = self.cache.generate_id(question=question)
-            sql = vn.generate_sql(question=question, allow_llm_to_see_data=self.allow_llm_to_see_data)
+            sql = vn.generate_sql(
+                question=question, allow_llm_to_see_data=self.allow_llm_to_see_data
+            )
+            # Generates a summary of the SQL query
+            summary = vn.generate_sql_summary(question=question, sql=sql)
+            # Style the final output to be more readable
+            results = f"{summary}\n\nSQL Query:\n\n{sql}"
 
             self.cache.set(user=user, id=id, field="question", value=question)
             self.cache.set(user=user, id=id, field="sql", value=sql)
@@ -364,7 +381,7 @@ class VannaFlaskAPI:
                     {
                         "type": "sql",
                         "id": id,
-                        "text": sql,
+                        "text": results,
                     }
                 )
             else:
@@ -396,9 +413,13 @@ class VannaFlaskAPI:
             last_question = flask.request.args.get("last_question")
             new_question = flask.request.args.get("new_question")
 
-            rewritten_question = self.vn.generate_rewritten_question(last_question, new_question)
+            rewritten_question = self.vn.generate_rewritten_question(
+                last_question, new_question
+            )
 
-            return jsonify({"type": "rewritten_question", "question": rewritten_question})
+            return jsonify(
+                {"type": "rewritten_question", "question": rewritten_question}
+            )
 
         @self.flask_app.route("/api/v0/get_function", methods=["GET"])
         @self.requires_auth
@@ -432,7 +453,12 @@ class VannaFlaskAPI:
                 return jsonify({"type": "error", "error": "No question provided"})
 
             if not hasattr(vn, "get_function"):
-                return jsonify({"type": "error", "error": "This setup does not support function generation."})
+                return jsonify(
+                    {
+                        "type": "error",
+                        "error": "This setup does not support function generation.",
+                    }
+                )
 
             id = self.cache.generate_id(question=question)
             function = vn.get_function(question=question)
@@ -440,15 +466,26 @@ class VannaFlaskAPI:
             if function is None:
                 return jsonify({"type": "error", "error": "No function found"})
 
-            if 'instantiated_sql' not in function:
+            if "instantiated_sql" not in function:
                 self.vn.log(f"No instantiated SQL found for {question} in {function}")
                 return jsonify({"type": "error", "error": "No instantiated SQL found"})
 
             self.cache.set(user=user, id=id, field="question", value=question)
-            self.cache.set(user=user, id=id, field="sql", value=function['instantiated_sql'])
+            self.cache.set(
+                user=user, id=id, field="sql", value=function["instantiated_sql"]
+            )
 
-            if 'instantiated_post_processing_code' in function and function['instantiated_post_processing_code'] is not None and len(function['instantiated_post_processing_code']) > 0:
-                self.cache.set(user=user, id=id, field="plotly_code", value=function['instantiated_post_processing_code'])
+            if (
+                "instantiated_post_processing_code" in function
+                and function["instantiated_post_processing_code"] is not None
+                and len(function["instantiated_post_processing_code"]) > 0
+            ):
+                self.cache.set(
+                    user=user,
+                    id=id,
+                    field="plotly_code",
+                    value=function["instantiated_post_processing_code"],
+                )
 
             return jsonify(
                 {
@@ -479,7 +516,12 @@ class VannaFlaskAPI:
                       type: array
             """
             if not hasattr(vn, "get_all_functions"):
-                return jsonify({"type": "error", "error": "This setup does not support function generation."})
+                return jsonify(
+                    {
+                        "type": "error",
+                        "error": "This setup does not support function generation.",
+                    }
+                )
 
             functions = vn.get_all_functions()
 
@@ -536,8 +578,9 @@ class VannaFlaskAPI:
                     {
                         "type": "df",
                         "id": id,
-                        "df": df.head(10).to_json(orient='records', date_format='iso'),
-                        "should_generate_chart": self.chart and vn.should_generate_chart(df),
+                        "df": df.head(10).to_json(orient="records", date_format="iso"),
+                        "should_generate_chart": self.chart
+                        and vn.should_generate_chart(df),
                     }
                 )
 
@@ -594,8 +637,7 @@ class VannaFlaskAPI:
                 }
             )
 
-
-        @self.flask_app.route('/api/v0/update_sql', methods=['POST'])
+        @self.flask_app.route("/api/v0/update_sql", methods=["POST"])
         @self.requires_auth
         @self.requires_cache([])
         def update_sql(user: any, id: str):
@@ -626,19 +668,20 @@ class VannaFlaskAPI:
                     text:
                       type: string
             """
-            sql = flask.request.json.get('sql')
+            sql = flask.request.json.get("sql")
 
             if sql is None:
                 return jsonify({"type": "error", "error": "No sql provided"})
 
-            self.cache.set(user=user, id=id, field='sql', value=sql)
+            self.cache.set(user=user, id=id, field="sql", value=sql)
 
             return jsonify(
                 {
                     "type": "sql",
                     "id": id,
                     "text": sql,
-                })
+                }
+            )
 
         @self.flask_app.route("/api/v0/download_csv", methods=["GET"])
         @self.requires_auth
@@ -696,7 +739,7 @@ class VannaFlaskAPI:
                     fig:
                       type: object
             """
-            chart_instructions = flask.request.args.get('chart_instructions')
+            chart_instructions = flask.request.args.get("chart_instructions")
 
             try:
                 # If chart_instructions is not set then attempt to retrieve the code from the cache
@@ -882,7 +925,9 @@ class VannaFlaskAPI:
             if plotly_code is None:
                 plotly_code = ""
 
-            function_data = self.vn.create_function(question=question, sql=sql, plotly_code=plotly_code)
+            function_data = self.vn.create_function(
+                question=question, sql=sql, plotly_code=plotly_code
+            )
 
             return jsonify(
                 {
@@ -923,7 +968,9 @@ class VannaFlaskAPI:
             print("old_function_name", old_function_name)
             print("updated_function", updated_function)
 
-            updated = vn.update_function(old_function_name=old_function_name, updated_function=updated_function)
+            updated = vn.update_function(
+                old_function_name=old_function_name, updated_function=updated_function
+            )
 
             return jsonify({"success": updated})
 
@@ -988,7 +1035,12 @@ class VannaFlaskAPI:
                 if followup_questions is not None and len(followup_questions) > 5:
                     followup_questions = followup_questions[:5]
 
-                self.cache.set(user=user, id=id, field="followup_questions", value=followup_questions)
+                self.cache.set(
+                    user=user,
+                    id=id,
+                    field="followup_questions",
+                    value=followup_questions,
+                )
 
                 return jsonify(
                     {
@@ -1060,8 +1112,7 @@ class VannaFlaskAPI:
         @self.flask_app.route("/api/v0/load_question", methods=["GET"])
         @self.requires_auth
         @self.requires_cache(
-            ["question", "sql", "df"],
-            optional_fields=["summary", "fig_json"]
+            ["question", "sql", "df"], optional_fields=["summary", "fig_json"]
         )
         def load_question(user: any, id: str, question, sql, df, fig_json, summary):
             """
@@ -1147,13 +1198,16 @@ class VannaFlaskAPI:
             )
 
         if self.debug:
+
             @self.sock.route("/api/v0/log")
             def sock_log(ws):
                 self.ws_clients.append(ws)
 
                 try:
                     while True:
-                        message = ws.receive()  # This example just reads and ignores to keep the socket open
+                        message = (
+                            ws.receive()
+                        )  # This example just reads and ignores to keep the socket open
                 finally:
                     self.ws_clients.remove(ws)
 
@@ -1184,7 +1238,9 @@ class VannaFlaskAPI:
                 print("Your app is running at:")
                 print("http://localhost:8084")
 
-            self.flask_app.run(host="0.0.0.0", port=8084, debug=self.debug, use_reloader=False)
+            self.flask_app.run(
+                host="0.0.0.0", port=8084, debug=self.debug, use_reloader=False
+            )
 
 
 class VannaFlaskApp(VannaFlaskAPI):
@@ -1258,8 +1314,10 @@ class VannaFlaskApp(VannaFlaskAPI):
         self.config["ask_results_correct"] = ask_results_correct
         self.config["followup_questions"] = followup_questions
         self.config["summarization"] = summarization
-        self.config["function_generation"] = function_generation and hasattr(vn, "get_function")
-        self.config["version"] = importlib.metadata.version('vanna')
+        self.config["function_generation"] = function_generation and hasattr(
+            vn, "get_function"
+        )
+        self.config["version"] = importlib.metadata.version("vanna")
 
         self.index_html_path = index_html_path
         self.assets_folder = assets_folder
@@ -1275,7 +1333,6 @@ class VannaFlaskApp(VannaFlaskAPI):
         @self.flask_app.route("/auth/logout", methods=["GET"])
         def logout():
             return self.auth.logout_handler(flask.request)
-
 
         @self.flask_app.route("/assets/<path:filename>")
         def proxy_assets(filename):


### PR DESCRIPTION
## Context

Updates the Vanna Flask App to include a summary of SQL steps in the UI.

### Primary Ticket
- [AB#21298 Queryous George | Mask SQL and summarize it instead](https://nrgmr.visualstudio.com/Data%20Engineering/_workitems/edit/21298/)

### Related PRs
- [106 Mask SQL and Add Summary](https://github.com/nrgmr/queryous-george/pull/106)

## Description
Modifies the `generate_sql` function lines 368-384 by adding:
- Summary of the SQL in human readable steps
- Formats it along with the SQL query to display in the UI
- Summary is display atop the SQL query