### PR TITLE
AB#21583 Update prompt for follow up questions

### DIFF
--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -2184,5 +2184,5 @@ class VannaBase(ABC):
 
         if dark_mode:
             fig.update_layout(template="plotly_dark")
-
+          
         return fig

--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -325,7 +325,19 @@ class VannaBase(ABC):
             return new_question
 
         prompt = [
-            self.system_message("Your goal is to rewrite the user's question based on whether it is a follow up question to their previous question. If the new question is fully self-contained and does not require the context of the the previous question to answer, return the new question. Otherwise, rewrite the user's new question by including the relevant context of the previous question and return the rewritten question with no additional explanations. The question should theoretically be answerable with a single SQL statement."),
+            self.system_message("""Your task is to analyze the user's new question in relation to their previous question and determine if it is a follow-up question or a standalone query. Follow these guidelines:
+
+1. If the new question is self-contained and doesn't require context from the previous question, return it unchanged.
+
+2. If the new question is a follow-up or related to the previous question, rewrite it to include relevant context from the previous question. The rewritten question should be comprehensive enough to be understood and answered without needing to refer back to the previous question.
+
+3. Focus on maintaining the specific intent and constraints of the new question while incorporating necessary context.
+
+4. Ensure the rewritten question can theoretically be answered with a single SQL statement.
+
+5. Return only the rewritten question or the original new question if no rewrite is needed. Do not include any explanations or additional text.
+
+6. Pay attention to time periods, entities, or other specific parameters mentioned in both questions that might need to be substituted, combined, and/or clarified in the rewritten question."""),
             self.user_message("Previous question: " + last_question + "\nNew question: " + new_question),
         ]
 

--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -325,8 +325,8 @@ class VannaBase(ABC):
             return new_question
 
         prompt = [
-            self.system_message("Your goal is to combine a sequence of questions into a singular question if they are related. If the second question does not relate to the first question and is fully self-contained, return the second question. Return just the new combined question with no additional explanations. The question should theoretically be answerable with a single SQL statement."),
-            self.user_message("First question: " + last_question + "\nSecond question: " + new_question),
+            self.system_message("Your goal is to rewrite the user's question based on whether it is a follow up question to their previous question. If the new question is fully self-contained and does not require the context of the the previous question to answer, return the new question. Otherwise, rewrite the user's new question by including the relevant context of the previous question and return the rewritten question with no additional explanations. The question should theoretically be answerable with a single SQL statement."),
+            self.user_message("Previous question: " + last_question + "\nNew question: " + new_question),
         ]
 
         return self.submit_prompt(prompt=prompt, **kwargs)


### PR DESCRIPTION
# Context

## Primary Ticket
[AB#21583](https://nrgmr.visualstudio.com/Data%20Engineering/_workitems/edit/21583) DE | Queryous George | Questions relations | Concatenating two non-related questions

## Description
When the user asks a follow up question, sometimes Vann decides to combine that question with the previous question. For example, the user starts by asking, "What titles were released in January 2025 in the US?" and proceeds to ask, "What titles were released in February 2025 in the US?" However, Vanna rewrites the second question as, "What titles were released in January and in February 2025 in the US?"

This PR updates the prompt used to generate rewritten follow up questions to mitigate this behavior. The new prompt is pasted below for convenience:

_Your goal is to rewrite the user's question based on whether it is a follow up question to their previous question. If the new question is fully self-contained and does not require the context of the the previous question to answer, return the new question. Otherwise, rewrite the user's new question by including the relevant context of the previous question and return the rewritten question with no additional explanations. The question should theoretically be answerable with a single SQL statement._

# Validation
<details>
<summary>What titles were released in January 2025 in the US?</summary>

![image](https://github.com/user-attachments/assets/f31d2b2c-18c7-47b5-8b41-75db3be7c6be)

</details>


<details>
<summary>What is the average number of hours spent streaming amongst men last year?</summary>

![image](https://github.com/user-attachments/assets/3823a745-1892-46e2-b098-b2ae469e29ff)

</details>

# Risks
I have not been able to get Vanna to successfully rewrite the follow up question. For example, when I ask these questions in sequence:
1. What is the average number of hours spent streaming amongst men last year?
2. What about amongst women?

Interestingly, Vanna always attempts to answer, "Can you break down sequel interest in the white lotus by income" instead of answering the second question, even though this question is not retrieved from the vector database.